### PR TITLE
u-boot-internal.inc: Do not check the SHA validation for branch

### DIFF
--- a/meta-intel-edison-bsp/recipes-bsp/u-boot/files/target_env/blankcdc.env
+++ b/meta-intel-edison-bsp/recipes-bsp/u-boot/files/target_env/blankcdc.env
@@ -6,5 +6,5 @@ do_flash_os_done=1
 bootargs_target=multi-user
 bootargs_ethconfig=cdc
 dfu_to_sec=3
-do_probe_dfu=run do_dfu_alt_info_mmc ; dfu 0 mmc 0 $dfu_to_sec
+do_probe_dfu=run do_dfu_alt_info_mmc ; dfu 0 mmc 0 ${dfu_to_sec}
 boot_target_cmd=run do_flash_os;run do_probe_dfu;run do_compute_target;run mmc-bootargs;run load_kernel;zboot ${loadaddr}

--- a/meta-intel-edison-bsp/recipes-bsp/u-boot/files/target_env/blankrndis.env
+++ b/meta-intel-edison-bsp/recipes-bsp/u-boot/files/target_env/blankrndis.env
@@ -6,5 +6,5 @@ do_flash_os_done=1
 bootargs_target=multi-user
 bootargs_ethconfig=rndis
 dfu_to_sec=3
-do_probe_dfu=run do_dfu_alt_info_mmc ; dfu 0 mmc 0 $dfu_to_sec
+do_probe_dfu=run do_dfu_alt_info_mmc ; dfu 0 mmc 0 ${dfu_to_sec}
 boot_target_cmd=run do_flash_os;run do_probe_dfu;run do_compute_target;run mmc-bootargs;run load_kernel;zboot ${loadaddr}

--- a/meta-intel-edison-bsp/recipes-bsp/u-boot/u-boot-internal.inc
+++ b/meta-intel-edison-bsp/recipes-bsp/u-boot/u-boot-internal.inc
@@ -3,7 +3,7 @@ S = "${WORKDIR}/git"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-SRC_URI = "git://github.com/andy-shev/u-boot.git;branch=edison;protocol=https"
+SRC_URI = "git://github.com/andy-shev/u-boot.git;nobranch=1;protocol=https"
 SRC_URI[md5sum] = "f99abb96f7c9c9c0d0d597acb896ca64"
 SRCREV = "edison-v2017.05"
 SRC_URI += "file://${MACHINE}.env"


### PR DESCRIPTION
Specifying the branch name and having the tag set as SRCREV makes bitbake error out:

WARNING: u-boot-edison-v2017.03-r0 do_fetch: Failed to fetch URL git://github.com/andy-shev/u-boot.git;branch=edison;protocol=https, attempting MIRRORS if available
ERROR: u-boot-edison-v2017.03-r0 do_fetch: Fetcher failure: Unable to find revision 506270615cf8e567b0b153bd5c2de47c35f671f8 in branch edison even from upstream
ERROR: u-boot-edison-v2017.03-r0 do_fetch: Fetcher failure for URL: 'git://github.com/andy-shev/u-boot.git;branch=edison;protocol=https'. Unable to fetch URL from any source.
ERROR: u-boot-edison-v2017.03-r0 do_fetch: Function failed: base_do_fetch

From http://git.yoctoproject.org/cgit.cgi/poky/plain/bitbake/lib/bb/fetch2/git.py:

- nobranch
   Don't check the SHA validation for branch. set this option for the recipe
   referring to commit which is valid in tag instead of branch.
   The default is "0", set nobranch=1 if needed.

Signed-off-by: Florin Sarbu <florin@resin.io>