### PR TITLE
Add proper initramfs image generation

### DIFF
--- a/initramfs.conf
+++ b/initramfs.conf
@@ -1,6 +1,0 @@
-INITRAMFS_IMAGE = "core-image-minimal-initramfs"
-INITRAMFS_IMAGE_BUNDLE = "1"
-INITRAMFS_MAXSIZE ="15728640"
- 
-IMAGE_FSTYPES = "cpio.gz"
-IMAGE_INSTALL+="kernel-modules"

--- a/meta-intel-edison-bsp/conf/machine/edison.conf
+++ b/meta-intel-edison-bsp/conf/machine/edison.conf
@@ -10,6 +10,10 @@ DEFAULTTUNE = "core2-64"
 
 MACHINE_FEATURES = "bluetooth alsa pci serial usbgadget usbhost wifi x86 ext3"
 KERNEL_IMAGETYPE = "bzImage"
+INITRAMFS_IMAGE = "core-image-minimal-initramfs"
+INITRAMFS_IMAGE_BUNDLE = "1"
+INITRAMFS_MAXSIZE ="15728640"
+INITRAMFS_FSTYPES = "cpio.gz"
 SERIAL_CONSOLES = "115200;ttyS2"
 UBOOT_MACHINE = "edison_defconfig"
 


### PR DESCRIPTION
As we've discussed in the other thread, I have to test this first, however as this would take me a while (need to do the u-boot build and update on my Edison first) and it actually looks ok, by inspecting the produced files - I figured I'll send the PR in parallel, in case you'd be willing/able to test this sooner. If not, no worries, I'll post a comment when I confirm this works.

The separate config is no longer needed and I've moved the relevant pieces of it to the machine config, as per [Yocto manual](http://www.yoctoproject.org/docs/2.3.2/dev-manual/dev-manual.html#building-an-initramfs-image) recommendations. It actually says to put one piece into `local.conf` and another - into machine conf, but IMHO they could be naturally stored as a single logical piece in the machine one.

I'll also take care of updating wiki build instructions when/if this is merged.