### PR TITLE
edison-image: generate hddimg

### DIFF
--- a/meta-intel-edison-distro/conf/distro/poky-edison.conf
+++ b/meta-intel-edison-distro/conf/distro/poky-edison.conf
@@ -22,4 +22,4 @@ VIRTUAL-RUNTIME_initscripts = ""
 VIRTUAL-RUNTIME_init_manager = "systemd"
 # Uncomment to completely disable support for sysv scripts:
 # Build and install bluez5 experimental tools and plugins
-PACKAGECONFIG_pn-bluez5 += "experimental obex-profiles"
+PACKAGECONFIG_pn-bluez5 += "experimental readline"

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -16,27 +16,12 @@ PCBIOS = "0"
 NOISO = "1"
 ROOTFS = ""
 
-# This is useless stuff, but necessary for building because
-# inheriting bootimg also brings syslinux in..
 AUTO_SYSLINUXCFG = "1"
-SYSLINUX_ROOT = ""
-SYSLINUX_TIMEOUT ?= "10"
-SYSLINUX_LABELS ?= "boot install"
-LABELS_append = " ${SYSLINUX_LABELS} "
-
 
 # Specify rootfs image type
-IMAGE_FSTYPES = "ext4"
-
-inherit core-image
-
-# This has to be set after including core-image otherwise it's overriden with "1"
-# and this cancel creation of the boot hddimg
+IMAGE_FSTYPES = "ext4 live"
 NOHDD = "0"
-
-#disabled this, don't know the effect
-#inherit bootimg
-do_bootimg[depends] += "${PN}:do_rootfs"
+inherit core-image
 
 IMAGE_ROOTFS_SIZE = "1048576"
 


### PR DESCRIPTION
flashall expects hddimg containin boot (live) image

Signed-off-by: Ferry Toth <ftoth@exalondelft.nl>