### PR TITLE
edison-image.bb: Generate live image with initramfs kernel

### DIFF
--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -7,36 +7,26 @@ IMAGE_INSTALL += "openssh-sftp-server"
 
 IMAGE_LINGUAS = " "
 
-INITRD = ""
-INITRD_IMAGE = ""
+# We don't want to include initrd - we have initramfs instead
+INITRD_LIVE = ""
 
 # Do not use legacy nor EFI BIOS
 PCBIOS = "0"
 # Do not support bootable USB stick
 NOISO = "1"
+# Generate a HDD image
+NOHDD = "0"
 ROOTFS = ""
 
-# This is useless stuff, but necessary for building because
-# inheriting bootimg also brings syslinux in..
-AUTO_SYSLINUXCFG = "1"
-SYSLINUX_ROOT = ""
-SYSLINUX_TIMEOUT ?= "10"
-SYSLINUX_LABELS ?= "boot install"
-LABELS_append = " ${SYSLINUX_LABELS} "
-
-
 # Specify rootfs image type
-IMAGE_FSTYPES = "ext4"
+IMAGE_FSTYPES = "ext4 live"
+# There seems to be no dedicated mechanism for picking initramfs
+# kernel for the live image - it tries to use the initrd unconditionally.
+# But this variable allows us to pick the kernel that gets packed,
+# into the image, see live-vm-common.bbclass.
+VM_DEFAULT_KERNEL = "bzImage-initramfs-edison.bin"
 
 inherit core-image
-
-# This has to be set after including core-image otherwise it's overriden with "1"
-# and this cancel creation of the boot hddimg
-NOHDD = "0"
-
-#disabled this, don't know the effect
-#inherit bootimg
-do_bootimg[depends] += "${PN}:do_rootfs"
 
 IMAGE_ROOTFS_SIZE = "1048576"
 


### PR DESCRIPTION
Here goes my config I came up with after analyzing reasons https://github.com/htot/meta-intel-edison/pull/14 didn't work as expected. There's basically a combination of newer Yocto (different variables) and no direct support for using initramfs kernel for live images. However there *is* a way and it doesn't even look like [too much of a] a hack to me :) I've added comments to make sure we are able to recall what and why down the road.

Here's how it looks like after generation:
```shell
ed@bl-ub$ ll /mnt1
total 11348
drwxr-xr-x  2 root root    16384 Jan  1  1970 ./
drwxr-xr-x 28 root root     4096 Dec 25 21:27 ../
-r-xr-xr-x  1 root root   122308 Dec 25 22:35 ldlinux.c32*
-r-xr-xr-x  1 root root    69632 Dec 25 22:35 ldlinux.sys*
-rwxr-xr-x  1 root root   186500 Dec 25 22:35 libcom32.c32*
-rwxr-xr-x  1 root root    24148 Dec 25 22:35 libutil.c32*
-rwxr-xr-x  1 root root      592 Dec 25 22:35 syslinux.cfg*
-rwxr-xr-x  1 root root    27104 Dec 25 22:35 vesamenu.c32*
-rwxr-xr-x  1 root root 11161872 Dec 25 22:35 vmlinuz*

ed@bl-ub$ ll bzImage--4.14.0-r0-edison-20171210145327.bin 
-rw-r--r-- 2 ed ed 7651600 Dec 10 16:12 bzImage--4.14.0-r0-edison-20171210145327.bin

ed@bl-ub$ ll bzImage-initramfs-4.14.0-r0-edison-20171210145327.bin 
-rw-r--r-- 2 ed ed 11161872 Dec 10 16:12 bzImage-initramfs-4.14.0-r0-edison-20171210145327.bin
```

By the way, original Edison (release 3.5) image looks like this, just for reference. Looking at the recipe, they disable initrd generation, but at the same time don't use the initramfs kernel.

```shell
ed@bl-ub$ ll /mnt
total 5530
drwxr-xr-x  2 root root   16384 Jan  1  1970 ./
drwxr-xr-x 28 root root    4096 Dec 25 21:27 ../
-r-xr-xr-x  1 root root  115472 Dec  3  2016 ldlinux.c32*
-r-xr-xr-x  1 root root   59904 Dec  3  2016 ldlinux.sys*
-rwxr-xr-x  1 root root     198 Dec  3  2016 syslinux.cfg*
-rwxr-xr-x  1 root root 5460640 Dec  3  2016 vmlinuz*
```