### PR TITLE
Rocko64 acpi

### DIFF
--- a/meta-intel-edison-bsp/recipes-kernel/linux/files/0001-Bluetooth-hci_serdev-Init-hci_uart-proto_lock-to-avo.patch
+++ b/meta-intel-edison-bsp/recipes-kernel/linux/files/0001-Bluetooth-hci_serdev-Init-hci_uart-proto_lock-to-avo.patch
@@ -1,0 +1,63 @@
+From b6780881d56d9af01611d148330cc896ac1392a8 Mon Sep 17 00:00:00 2001
+From: Lukas Wunner <lukas@wunner.de>
+Date: Fri, 17 Nov 2017 00:54:53 +0100
+Subject: [PATCH] Bluetooth: hci_serdev: Init hci_uart proto_lock to avoid oops
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+John Stultz reports a boot time crash with the HiKey board (which uses
+hci_serdev) occurring in hci_uart_tx_wakeup().  That function is
+contained in hci_ldisc.c, but also called from the newer hci_serdev.c.
+It acquires the proto_lock in struct hci_uart and it turns out that we
+forgot to init the lock in the serdev code path, thus causing the crash.
+
+John bisected the crash to commit 67d2f8781b9f ("Bluetooth: hci_ldisc:
+Allow sleeping while proto locks are held"), but the issue was present
+before and the commit merely exposed it.  (Perhaps by luck, the crash
+did not occur with rwlocks.)
+
+Init the proto_lock in the serdev code path to avoid the oops.
+
+Stack trace for posterity:
+
+Unable to handle kernel read from unreadable memory at 406f127000
+[000000406f127000] user address but active_mm is swapper
+Internal error: Oops: 96000005 [#1] PREEMPT SMP
+Hardware name: HiKey Development Board (DT)
+Call trace:
+ hci_uart_tx_wakeup+0x38/0x148
+ hci_uart_send_frame+0x28/0x38
+ hci_send_frame+0x64/0xc0
+ hci_cmd_work+0x98/0x110
+ process_one_work+0x134/0x330
+ worker_thread+0x130/0x468
+ kthread+0xf8/0x128
+ ret_from_fork+0x10/0x18
+
+Link: https://lkml.org/lkml/2017/11/15/908
+Reported-and-tested-by: John Stultz <john.stultz@linaro.org>
+Cc: Ronald Tschalär <ronald@innovation.ch>
+Cc: Rob Herring <rob.herring@linaro.org>
+Cc: Sumit Semwal <sumit.semwal@linaro.org>
+Signed-off-by: Lukas Wunner <lukas@wunner.de>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/hci_serdev.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/bluetooth/hci_serdev.c b/drivers/bluetooth/hci_serdev.c
+index 71664b22ec9d..e0e6461b9200 100644
+--- a/drivers/bluetooth/hci_serdev.c
++++ b/drivers/bluetooth/hci_serdev.c
+@@ -303,6 +303,7 @@ int hci_uart_register_device(struct hci_uart *hu,
+ 	hci_set_drvdata(hdev, hu);
+ 
+ 	INIT_WORK(&hu->write_work, hci_uart_write_work);
++	percpu_init_rwsem(&hu->proto_lock);
+ 
+ 	/* Only when vendor specific setup callback is provided, consider
+ 	 * the manufacturer information valid. This avoids filling in the
+-- 
+2.14.1
+

--- a/meta-intel-edison-bsp/recipes-kernel/linux/files/0001-perf-tools-Fix-compile-error-with-libunwind-x86.patch
+++ b/meta-intel-edison-bsp/recipes-kernel/linux/files/0001-perf-tools-Fix-compile-error-with-libunwind-x86.patch
@@ -1,0 +1,47 @@
+From c636b13385af41e823a997f6e9d075ff27c76815 Mon Sep 17 00:00:00 2001
+From: Wang Nan <wangnan0@huawei.com>
+Date: Wed, 6 Dec 2017 01:50:40 +0000
+Subject: [PATCH] perf tools: Fix compile error with libunwind x86
+
+Fix a compile error:
+
+ ...
+   CC       util/libunwind/x86_32.o
+ In file included from util/libunwind/x86_32.c:33:0:
+ util/libunwind/../../arch/x86/util/unwind-libunwind.c: In function 'libunwind__x86_reg_id':
+ util/libunwind/../../arch/x86/util/unwind-libunwind.c:110:11: error: 'EINVAL' undeclared (first use in this function)
+    return -EINVAL;
+            ^
+ util/libunwind/../../arch/x86/util/unwind-libunwind.c:110:11: note: each undeclared identifier is reported only once for each function it appears in
+ mv: cannot stat 'util/libunwind/.x86_32.o.tmp': No such file or directory
+ make[4]: *** [util/libunwind/x86_32.o] Error 1
+ make[3]: *** [util] Error 2
+ make[2]: *** [libperf-in.o] Error 2
+ make[1]: *** [sub-make] Error 2
+ make: *** [all] Error 2
+
+It happens when libunwind-x86 feature is detected.
+
+Signed-off-by: Wang Nan <wangnan0@huawei.com>
+Link: http://lkml.kernel.org/r/20171206015040.114574-1-wangnan0@huawei.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/arch/x86/util/unwind-libunwind.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/perf/arch/x86/util/unwind-libunwind.c b/tools/perf/arch/x86/util/unwind-libunwind.c
+index 9c917f80c906..05920e3edf7a 100644
+--- a/tools/perf/arch/x86/util/unwind-libunwind.c
++++ b/tools/perf/arch/x86/util/unwind-libunwind.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0
+ 
+-#ifndef REMOTE_UNWIND_LIBUNWIND
+ #include <errno.h>
++#ifndef REMOTE_UNWIND_LIBUNWIND
+ #include <libunwind.h>
+ #include "perf_regs.h"
+ #include "../../util/unwind.h"
+-- 
+2.14.1
+

--- a/meta-intel-edison-bsp/recipes-kernel/linux/files/serial-8250-Don-t-service-RX-FIFO-if-interrupts-are-disabled.patch
+++ b/meta-intel-edison-bsp/recipes-kernel/linux/files/serial-8250-Don-t-service-RX-FIFO-if-interrupts-are-disabled.patch
@@ -1,0 +1,45 @@
+From patchwork Thu Feb  8 12:55:41 2018
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Subject: [1/2] serial: 8250: Don't service RX FIFO if interrupts are disabled
+From: Vignesh R <vigneshr@ti.com>
+X-Patchwork-Id: 10207099
+Message-Id: <20180208125542.15649-2-vigneshr@ti.com>
+To: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Cc: Jiri Slaby <jslaby@suse.com>, Andy Shevchenko <andy.shevchenko@gmail.com>,
+ <linux-serial@vger.kernel.org>, <linux-kernel@vger.kernel.org>,
+ <linux-omap@vger.kernel.org>,
+ <linux-arm-kernel@lists.infradead.org>, Vignesh R <vigneshr@ti.com>
+Date: Thu, 8 Feb 2018 18:25:41 +0530
+
+Currently, data in RX FIFO is read based on UART_LSR register state even
+if RDI and RLSI interrupts are disabled in UART_IER register.
+This is because when IRQ handler is called due to TX FIFO empty event,
+RX FIFO is serviced based on UART_LSR register status instead of
+UART_IIR status. This defeats the purpose of disabling UART RX
+FIFO interrupts during throttling(see, omap_8250_throttle()) as IRQ
+handler continues to drain UART RX FIFO resulting in overflow of buffer
+at tty layer.
+Fix this by making sure that driver drains UART RX FIFO only when
+UART_IIR_RDI is set along with UART_LSR_BI or UART_LSR_DR bits.
+
+Signed-off-by: Vignesh R <vigneshr@ti.com>
+---
+ drivers/tty/serial/8250/8250_port.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
+index 1328c7e70108..ffbb955d1c06 100644
+--- a/drivers/tty/serial/8250/8250_port.c
++++ b/drivers/tty/serial/8250/8250_port.c
+@@ -1854,7 +1854,8 @@ int serial8250_handle_irq(struct uart_port *port, unsigned int iir)
+ 
+ 	status = serial_port_in(port, UART_LSR);
+ 
+-	if (status & (UART_LSR_DR | UART_LSR_BI)) {
++	if (status & (UART_LSR_DR | UART_LSR_BI) &&
++	    iir & UART_IIR_RDI) {
+ 		if (!up->dma || handle_rx_dma(up, iir))
+ 			status = serial8250_rx_chars(up, status);
+ 	}

--- a/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.15.0.bb
+++ b/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.15.0.bb
@@ -9,6 +9,7 @@ PV = "4.15.0"
 
 # this branch now contains both non-acpi kernel and acpi enabled kernel on top
 SRC_URI = "git://github.com/htot/linux.git;protocol=https;branch=eds-4.15.0-unified \
+	file://serial-8250-Don-t-service-RX-FIFO-if-interrupts-are-disabled.patch \
         file://usb_phy.cfg \
         file://usb_dwc3.cfg \
         file://ftdi_sio.cfg \

--- a/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.15.0.bb
+++ b/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.15.0.bb
@@ -11,6 +11,7 @@ PV = "4.15.0"
 SRC_URI = "git://github.com/htot/linux.git;protocol=https;branch=eds-4.15.0-unified \
         file://serial-8250-Don-t-service-RX-FIFO-if-interrupts-are-disabled.patch \
         file://0001-perf-tools-Fix-compile-error-with-libunwind-x86.patch \
+	file://0001-Bluetooth-hci_serdev-Init-hci_uart-proto_lock-to-avo.patch \
         file://usb_phy.cfg \
         file://usb_dwc3.cfg \
         file://ftdi_sio.cfg \

--- a/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.15.0.bb
+++ b/meta-intel-edison-bsp/recipes-kernel/linux/linux-yocto_4.15.0.bb
@@ -9,7 +9,8 @@ PV = "4.15.0"
 
 # this branch now contains both non-acpi kernel and acpi enabled kernel on top
 SRC_URI = "git://github.com/htot/linux.git;protocol=https;branch=eds-4.15.0-unified \
-	file://serial-8250-Don-t-service-RX-FIFO-if-interrupts-are-disabled.patch \
+        file://serial-8250-Don-t-service-RX-FIFO-if-interrupts-are-disabled.patch \
+        file://0001-perf-tools-Fix-compile-error-with-libunwind-x86.patch \
         file://usb_phy.cfg \
         file://usb_dwc3.cfg \
         file://ftdi_sio.cfg \

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -1,6 +1,5 @@
 DESCRIPTION = "A fully functional image to run EDISON"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
-                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 LICENSE = "MIT"
 IMAGE_INSTALL = "packagegroup-core-boot  ${CORE_IMAGE_EXTRA_INSTALL}"
 IMAGE_INSTALL_append = " openssh-sftp-server"

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -86,8 +86,6 @@ IMAGE_INSTALL_append = " python-distutils python-pkgutil python-audio python-ima
 # Wifi firmware
 # removed modules, already built into kernel
 IMAGE_INSTALL_append = " bcm43340-fw"
-# service daemon that listens to rfkill events and trigger FW patch download
-IMAGE_INSTALL_append = " bluetooth-rfkill-event"
 
 # Provides strace and gdb
 IMAGE_FEATURES += "tools-debug"

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -98,6 +98,7 @@ IMAGE_INSTALL_append = " tcpdump"
 IMAGE_INSTALL_append = " net-tools"
 IMAGE_INSTALL_append = " lsof"
 IMAGE_INSTALL_append = " iperf3"
+IMAGE_INSTALL_append = " less"
 
 # Add pulseaudio
 IMAGE_INSTALL_append = " pulseaudio-server libpulsecore libpulsecommon libpulse libpulse-simple pulseaudio-misc"

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -168,4 +168,7 @@ IMAGE_INSTALL_append = " acpi-tables"
 # package management - where to find this?
 #IMAGE_INSTALL_append = " aptitude"
 
+# Add monitoring tools
+IMAGE_INSTALL_append = " htop"
+
 DEPENDS += "u-boot"

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -171,5 +171,6 @@ IMAGE_INSTALL_append = " acpi-tables"
 # Add monitoring tools
 IMAGE_INSTALL_append = " htop"
 IMAGE_INSTALL_append = " iotop"
+IMAGE_INSTALL_append = " powertop"
 
 DEPENDS += "u-boot"

--- a/meta-intel-edison-distro/recipes-core/images/edison-image.bb
+++ b/meta-intel-edison-distro/recipes-core/images/edison-image.bb
@@ -170,5 +170,6 @@ IMAGE_INSTALL_append = " acpi-tables"
 
 # Add monitoring tools
 IMAGE_INSTALL_append = " htop"
+IMAGE_INSTALL_append = " iotop"
 
 DEPENDS += "u-boot"

--- a/utils/flash/postBuild.sh
+++ b/utils/flash/postBuild.sh
@@ -75,10 +75,10 @@ cp -R $top_repo_dir/meta-intel-edison/utils/flash/helper $build_dir/toFlash/help
 ubootdir=$top_repo_dir/u-boot
 mkimage_tool_path=""
 if [ -a $ubootdir ]; then
-    mkimage_tool_path=$(find $top_repo_dir/u-boot -name mkimage)
+    mkimage_tool_path=$(find $top_repo_dir/u-boot -name mkimage -type f)
 fi
 if [ -z $mkimage_tool_path ]; then
-    mkimage_tool_path=$(find $build_dir/tmp/work/edison-poky-linux/u-boot -name mkimage)
+    mkimage_tool_path=$(find $build_dir/tmp/work/edison-poky-linux/u-boot -name mkimage -type f)
     if [ -z "$mkimage_tool_path" ]; then
         echo "Error : ota_update.scr creation failed, mkimage tool not found"
         exit 0


### PR DESCRIPTION
This has some fixes to enable build for x86_32, cleanups, adds some tools in particular `less`, needed to decently colorize journalctl output and fixes postbuild script error.