### PR TITLE
Update meta-mingw patch for SDKTAROPTS

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -350,7 +350,7 @@ COPYLEFT_LICENSE_INCLUDE = 'GPL* LGPL*'
   # Apply patch on top of it allowing to perform build in external source directory
   echo "Applying patch on poky"
   cd $mingw_dir
-  git apply $top_repo_dir/meta-intel-edison/utils/0001-Revert-machine-sdk-mingw32.conf-Disable-SDKTAROPTS.patch
+  git apply $top_repo_dir/meta-intel-edison/utils/0001-Enable-SDKTAROPTS.patch
   cd $poky_dir
 
   if [[ $my_sdk_host == win* ]]

--- a/utils/0001-Enable-SDKTAROPTS.patch
+++ b/utils/0001-Enable-SDKTAROPTS.patch
@@ -1,0 +1,46 @@
+From 313d19d3675971d0419a1810effaf5b52be86537 Mon Sep 17 00:00:00 2001
+From: Alex Tereschenko <alext.mkrs@gmail.com>
+Date: Wed, 6 Jun 2018 21:59:00 +0200
+Subject: [PATCH] Enable SDKTAROPTS
+
+Ported from original patch by Fabien Rodriguez <fabienx.rodriguez@intel.com>
+
+Signed-off-by: Alex Tereschenko <alext.mkrs@gmail.com>
+---
+ conf/machine-sdk/i686-mingw32.conf   | 4 +---
+ conf/machine-sdk/x86_64-mingw32.conf | 4 +---
+ 2 files changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/conf/machine-sdk/i686-mingw32.conf b/conf/machine-sdk/i686-mingw32.conf
+index 458d1f7..baabd99 100644
+--- a/conf/machine-sdk/i686-mingw32.conf
++++ b/conf/machine-sdk/i686-mingw32.conf
+@@ -16,9 +16,7 @@ ALLOW_EMPTY_${PN}_mingw32 = "1"
+ 
+ # Do what amounts to a NOOP
+ SDK_PACKAGING_FUNC = "do_compile"
+-
+-# Causes an endless loop
+-#SDKTAROPTS_append = " -h --hard-dereference"
++SDKTAROPTS_append = " -h --hard-dereference"
+ 
+ SDKUSE_NLS = "no"
+ SDKIMAGE_LINGUAS = ""
+diff --git a/conf/machine-sdk/x86_64-mingw32.conf b/conf/machine-sdk/x86_64-mingw32.conf
+index 61e6112..d1704b9 100644
+--- a/conf/machine-sdk/x86_64-mingw32.conf
++++ b/conf/machine-sdk/x86_64-mingw32.conf
+@@ -16,9 +16,7 @@ ALLOW_EMPTY_${PN}_mingw32 = "1"
+ 
+ # Do what amounts to a NOOP
+ SDK_PACKAGING_FUNC = "do_compile"
+-
+-# Causes an endless loop
+-#SDKTAROPTS_append = " -h --hard-dereference"
++SDKTAROPTS_append = " -h --hard-dereference"
+ 
+ SDKUSE_NLS = "no"
+ SDKIMAGE_LINGUAS = ""
+-- 
+2.7.4
+


### PR DESCRIPTION
Okay, so looks like that `meta-mingw` patching problem we discussed in https://github.com/htot/meta-intel-edison/issues/6 still exists, at least in `master`. Here's a fix.

Master is a current branch for development and it should be stable enough to run on Edison, right? Except for ACPI being enabled by default maybe.